### PR TITLE
add brl coin

### DIFF
--- a/lib/core/utils/currencies.dart
+++ b/lib/core/utils/currencies.dart
@@ -3,5 +3,6 @@ import 'package:expense_bud/features/settings/domain/entities/currency.dart';
 const usd = CurrencyEntity(name: 'USD', locale: "en_US", symbol: "\u0024");
 const ngn = CurrencyEntity(name: 'NGN', locale: "en_NG", symbol: "\u20A6");
 const gbp = CurrencyEntity(name: 'GBP', locale: "en_GB", symbol: "\u00A3");
+const brl = CurrencyEntity(name: 'BRL', locale: "pt_BR", symbol: "\u0052\u0024");
 
-List<CurrencyEntity> currencyList() => [usd, gbp, ngn];
+List<CurrencyEntity> currencyList() => [usd, gbp, ngn, brl];


### PR DESCRIPTION
Add Brazilian Real currency.
BRL is just a capital latin R followed by a dollar sign.
It's formatted using this pattern:
` code="BRL" unicode-decimal="82, 36" unicode-hex="52, 24">`

Tested on my device. The app already displays the correct format in different decimals.